### PR TITLE
issue 10 - fix delete tags when tag values have spaces in them

### DIFF
--- a/metrics/client.go
+++ b/metrics/client.go
@@ -411,6 +411,10 @@ func (c *Client) UpdateTags(t MetricType, id string, tags map[string]string, o .
 
 // DeleteTags deletes given tags from the definition
 func (c *Client) DeleteTags(t MetricType, id string, tags map[string]string, o ...Modifier) error {
+	for k, _ := range tags {
+		tags[k]="a"
+	}
+
 	o = prepend(o, c.URL("DELETE", TypeEndpoint(t), SingleMetricEndpoint(id), TagEndpoint(), TagsEndpoint(tags)))
 
 	r, err := c.Send(o...)

--- a/metrics/client_test.go
+++ b/metrics/client_test.go
@@ -178,7 +178,7 @@ func TestTagsModification(t *testing.T) {
 	// Add tags
 	tags := make(map[string]string)
 	tags["ab"] = "ac"
-	tags["host"] = "test"
+	tags["host"] = "test with space"
 	err = c.UpdateTags(Gauge, id, tags)
 	assert.Nil(t, err)
 


### PR DESCRIPTION
This is an alternative fix from PR #11 for issue #10 

Rather than completely removing the tag values from the DELETE URL (which is what that first PR does, but this won't work when talking to older H-Metric servers that expect to see both tag name and value in the DELETE URL), this fix passes tag values, but they are not the original tag values - they are dummy values ("a"). So it still passes tag names AND values, but the values are guaranteed not to have spaces in them and thus won't cause error 400 responses. I do not know if older H-Metric servers actually required you to send in the actual value of the tag being deleted - if so, this PR is not backward compatible just as the original PR #11 was not backward compatible (but for different reasons - PR #11 is not backward compat because it does not pass tag values on the DELETE URL).